### PR TITLE
Fix namespace sort order in factory.template

### DIFF
--- a/templates/factory.template
+++ b/templates/factory.template
@@ -5,8 +5,8 @@
  */
 
 %namespace%
-use Psr\Container\ContainerInterface;
 use Laminas\Di\CodeGenerator\FactoryInterface;
+use Psr\Container\ContainerInterface;
 %use_array_key_exists%
 use function is_array;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Restores alphabetical sort order of namespace imports in `factory.template`.
