### PR TITLE
Simplify redirects of legacy docs

### DIFF
--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/codegen/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/codegen/';
-  });
-</script>

--- a/docs/book/config.md
+++ b/docs/book/config.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/config/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/config/';
-  });
-</script>

--- a/docs/book/cookbook/aot-guide.md
+++ b/docs/book/cookbook/aot-guide.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/cookbook/aot-guide/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/cookbook/aot-guide/';
-  });
-</script>

--- a/docs/book/cookbook/use-with-psr-containers.md
+++ b/docs/book/cookbook/use-with-psr-containers.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/cookbook/use-with-psr-containers/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/cookbook/use-with-psr-containers/';
-  });
-</script>

--- a/docs/book/cookbook/use-with-servicemanager.md
+++ b/docs/book/cookbook/use-with-servicemanager.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/cookbook/use-with-servicemanager/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/cookbook/use-with-servicemanager/';
-  });
-</script>

--- a/docs/book/injector.md
+++ b/docs/book/injector.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/injector/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/injector/';
-  });
-</script>

--- a/docs/book/installation.md
+++ b/docs/book/installation.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/installation/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/installation/';
-  });
-</script>

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/intro/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/intro/';
-  });
-</script>

--- a/docs/book/migration.md
+++ b/docs/book/migration.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/migration/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/migration/';
-  });
-</script>

--- a/docs/book/psr-11.md
+++ b/docs/book/psr-11.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/psr-11/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/psr-11/';
-  });
-</script>

--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-di/v3/quick-start/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-di/v3/quick-start/';
-  });
-</script>

--- a/docs/book/v3/codegen.md
+++ b/docs/book/v3/codegen.md
@@ -5,6 +5,7 @@ generators to create optimized code for production. These generators will
 inspect the provided classes, resolve their dependencies, and generate factories
 based on these results.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Removal of laminas-code dependencies
 >
 > Before version 3.1, this feature required [laminas-code](https://docs.laminas.dev/laminas-code/),
@@ -101,5 +102,5 @@ via an optional fourth constructor parameter.
 
 The generator will log the following information:
 
-* When a factory is about to be generated for a class or alias (Log level: Debug)
-* When the factory generation caused an exception (Log level: Error)
+- When a factory is about to be generated for a class or alias (Log level: Debug)
+- When the factory generation caused an exception (Log level: Error)

--- a/docs/book/v3/config.md
+++ b/docs/book/v3/config.md
@@ -140,7 +140,6 @@ $b = $injector->create('MyClass.A'); // Constructed with SpecialFoo
 $c = $injector->create('MyClass.B'); // Constructed with Foo (since Bar does not satisfy FooInterface)
 ```
 
-
 ## Parameters
 
 In contrast to type preferences, the resolver will not perform checks if the

--- a/docs/book/v3/injector.md
+++ b/docs/book/v3/injector.md
@@ -48,7 +48,6 @@ Generally the following behavior applies for parameter values that are not
 - If the parameter has no typehint at all, the value will be wrapped into a
   `ValueInjection`.
 
-
 ### Examples
 
 ```php

--- a/docs/book/v3/installation.md
+++ b/docs/book/v3/installation.md
@@ -1,3 +1,5 @@
+# Installation
+
 **This is only a placeholder.**
 
 The content of this page can be found under:

--- a/docs/book/v3/intro.md
+++ b/docs/book/v3/intro.md
@@ -35,7 +35,6 @@ This decision was made for several reasons:
 > - [Matthew Weier O'Phinney's Analogy](https://mwop.net/blog/260-Dependency-Injection-An-analogy.html)
 > - [Fabien Potencier's Series](http://fabien.potencier.org/article/11/what-is-dependency-injection) on DI
 
-
 > ### laminas-servicemanager
 >
 > Since laminas-di purely provides automatic DI (aka auto wiring), it does not

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,19 +23,6 @@ nav:
             - "Instance Manager": v2/instance-manager.md
             - Configuration: v2/config.md
             - "Debugging And Complex Use Cases": v2/debugging-and-complex-use-cases.md
-    - "_hidden-legacy-page-links":
-        - '_codegen': codegen.md
-        - '_config': config.md
-        - '_injector': injector.md
-        - '_installation': installation.md
-        - '_intro': intro.md
-        - '_migration': migration.md
-        - '_psr-11': psr-11.md
-        - '_quick-start': quick-start.md
-        - '_cookbook_aot_guide': cookbook/aot-guide.md
-        - '_cookbook_use_with_psr_containers': cookbook/use-with-psr-containers.md
-        - '_cookbook_use_with_servicemanager': cookbook/use-with-servicemanager.md
-
 site_name: laminas-di
 site_description: "Automated dependency injection for PSR-11 containers"
 repo_url: 'https://github.com/laminas/laminas-di'
@@ -48,3 +35,18 @@ extra:
     installation:
         config_provider_class: 'Laminas\Di\ConfigProvider'
         module_class: 'Laminas\Di\Module'
+plugins:
+    - search
+    - redirects:
+          redirect_maps:
+              codegen.md: v3/codegen.md
+              config.md: v3/config.md
+              injector.md: v3/injector.md
+              installation.md: v3/installation.md
+              intro.md: v3/intro.md
+              migration.md: v3/migration.md
+              psr-11.md: v3/psr-11.md
+              quick-start.md: v3/quick-start.md
+              cookbook/aot-guide.md: v3/cookbook/aot-guide.md
+              cookbook/use-with-psr-containers.md: v3/cookbook/use-with-psr-containers.md
+              cookbook/use-with-servicemanager.md: v3/cookbook/use-with-servicemanager.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The docs folder contains several manual redirects, i.d. HTML documents with a hard-coded redirect for legacy URLs. With the [adoption of the MkDocs redirect plugin](https://github.com/laminas/documentation-theme/pull/65) there is a simpler solution available.

This PR moves the redirects for legacy URLs in `mkdocs.yml` and removes the manually created HTML documents from Git.