### PR TITLE
CONFIG: Remove redundant shorthand ternary & fix typos

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -14,7 +14,7 @@ use function is_array;
 /**
  * Provides a DI configuration from an array.
  *
- * This configures the instanciation process of the dependency injector.
+ * This configures the instantiation process of the dependency injector.
  *
  * **Example:**
  *
@@ -27,17 +27,17 @@ use function is_array;
  *         // the types the dependency injector should prefer.
  *         Some\Interface::class => Some\Preference::class
  *     ],
- *     // This configures the instanciation of specific types.
+ *     // This configures the instantiation of specific types.
  *     // Types may also be purely virtual by defining the aliasOf key.
  *     'types' => [
  *         My\Class::class => [
  *              'preferences' => [
  *                  // this supercedes the global type preferences
- *                  // when My\Class is instanciated
+ *                  // when My\Class is instantiated
  *                  Some\Interface::class => 'My.SpecificAlias'
  *              ],
  *
- *              // Instanciation paramters. These will only be used for
+ *              // instantiation paramters. These will only be used for
  *              // the instantiator (i.e. the constructor)
  *              'parameters' => [
  *                  'foo' => My\FooImpl::class, // Use the given type to provide the injection (depends on definition)
@@ -94,8 +94,8 @@ class Config implements ConfigInterface
     public function __construct($options = [])
     {
         $this->ensureArrayOrArrayAccess($options);
-        $this->preferences = $this->getDataFromArray($options, 'preferences') ?: [];
-        $this->types       = $this->getDataFromArray($options, 'types') ?: [];
+        $this->preferences = $this->getDataFromArray($options, 'preferences');
+        $this->types       = $this->getDataFromArray($options, 'types');
     }
 
     /**
@@ -122,7 +122,7 @@ class Config implements ConfigInterface
     }
 
     /**
-     * Returns the instanciation paramters for the given type
+     * Returns the instantiation paramters for the given type
      *
      * @param string $type The alias or class name
      * @return array The configured parameters


### PR DESCRIPTION
`Config::getDataFromArray` ensures an array is returned hence the 
ternary in the `Config::__construct` seems redundant as the only case
the expression evaluates to false is when an empty array was returned
and does not need to be re-assigned.

Signed-off-by: Remy Bos <27890746+sjokkateer@users.noreply.github.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
The shorthand ternary statements in the constructor of the `Config::class` seem unnecessary and have hence been removed.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
