### PR TITLE
Adjust `Injector::create()` to ignore interfaces (which cannot be instantiated anyway)

### DIFF
--- a/src/Injector.php
+++ b/src/Injector.php
@@ -163,9 +163,9 @@ class Injector implements InjectorInterface
             ));
         }
 
-        if (! class_exists($class) || interface_exists($class)) {
+        if (! class_exists($class)) {
             throw new ClassNotFoundException(sprintf(
-                'Class or interface by name %s does not exist',
+                'Class by name %s does not exist',
                 $class
             ));
         }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -486,9 +486,8 @@ class InjectorTest extends TestCase
         $definition = $this->createMock(DefinitionInterface::class);
         $definition
             ->method('hasClass')
-            ->willReturn(true)
-        ;
-        
+            ->willReturn(true);
+
         $injector = new Injector(null, null, $definition);
 
         $this->expectException(ClassNotFoundException::class);

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -9,6 +9,7 @@ use Laminas\Di\Config;
 use Laminas\Di\DefaultContainer;
 use Laminas\Di\Definition\DefinitionInterface;
 use Laminas\Di\Exception;
+use Laminas\Di\Exception\ClassNotFoundException;
 use Laminas\Di\Injector;
 use Laminas\Di\Resolver\DependencyResolverInterface;
 use Laminas\Di\Resolver\TypeInjection;
@@ -478,5 +479,19 @@ class InjectorTest extends TestCase
     {
         $result = (new Injector())->create($class, $parameters);
         $this->assertEquals($parameters, $result->result);
+    }
+
+    public function testCreateGivenExistingInterfaceExpectedClassNotFoundExceptionThrown()
+    {
+        $definition = $this->createMock(DefinitionInterface::class);
+        $definition
+            ->method('hasClass')
+            ->willReturn(true)
+        ;
+        
+        $injector = new Injector(null, null, $definition);
+
+        $this->expectException(ClassNotFoundException::class);
+        $injector->create(DefinitionInterface::class);
     }
 }


### PR DESCRIPTION
Signed-off-by: Remy Bos <27890746+sjokkateer@users.noreply.github.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
[Injector::create#L166-171](https://github.com/laminas/laminas-di/blob/3.4.x/src/Injector.php#L166) contains the following check:
```php
if (! class_exists($class) || interface_exists($class)) {
    throw new ClassNotFoundException(sprintf(
        'Class or interface by name %s does not exist',
        $class
    ));
}
```
Given the added test (which passes/satisfies), a `ClassNotFoundException::class` is thrown. This is the case because the if guard short circuits ([example #1](https://www.php.net/manual/en/language.operators.logical.php)) since `! class_exists($class)` will always be true for any given interface. Therefor it seems that the part `|| interface_exists($class)` could hence be removed (all tests would still pass equally).

My main confusion with this piece of code lies in the fact that it seems as if it was meant for an interface to get up to that point, based on the given if guard and exception message.  While everything following the conditional indicates it not making sense. Since after the conditional, only parameters for a class will be resolved and an attempt is made to construct a class (which would ofcourse result in an error for an interface).

This confusion would be resolved by removing the `|| interface_exists($class)` and adjusting the message of the exception that is thrown.

I have made the pull request a WIP in case you have a different opinion than the suggested. Please let me know what you think.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
