### PR TITLE
Generator trait produces incorrect exception message for invalid directory paths

### DIFF
--- a/src/CodeGenerator/GeneratorTrait.php
+++ b/src/CodeGenerator/GeneratorTrait.php
@@ -34,7 +34,7 @@ trait GeneratorTrait
         if (! is_dir($dir) && ! mkdir($dir, $this->mode, true)) {
             throw new GenerateCodeException(sprintf(
                 'Could not create output directory: %s',
-                $this->outputDirectory
+                $dir
             ));
         }
     }

--- a/test/CodeGenerator/GeneratorTraitTest.php
+++ b/test/CodeGenerator/GeneratorTraitTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Di\CodeGenerator;
+
+use Laminas\Di\CodeGenerator\GeneratorTrait;
+use Laminas\Di\Exception\GenerateCodeException;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratorTraitTest extends TestCase
+{
+    public function testEnsureDirectoryGivenInvalidDirectoryNameExpectedErrorMessageContainInvalidDirectoryName(): void
+    {
+        $invalidDir = 'http://www.invalid-directory';
+
+        $this->expectException(GenerateCodeException::class);
+        $this->expectErrorMessage('Could not create output directory: ' . $invalidDir);
+
+        new class (__DIR__, $invalidDir)
+        {
+            use GeneratorTrait;
+
+            public function __construct(string $dir, string $otherDir)
+            {
+                $this->outputDirectory = $dir;
+
+                $this->ensureDirectory($otherDir);
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Within the `GeneratorTrait::ensureDirectory` it is possible to get back an exception message containing an incorrect directory name. This test plus modification should ensure the directory that could not be created is returned in the error message.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
