### PR TITLE
Simplify `RuntimeDefinition::class` by normalizing `RuntimeDefinition::$explicitClasses`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -236,11 +236,6 @@ parameters:
 			path: src/Definition/Reflection/Parameter.php
 
 		-
-			message: "#^Method Laminas\\\\Di\\\\Definition\\\\RuntimeDefinition\\:\\:loadClass\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Definition/RuntimeDefinition.php
-
-		-
 			message: "#^Method Laminas\\\\Di\\\\Injector\\:\\:create\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Injector.php

--- a/src/Definition/RuntimeDefinition.php
+++ b/src/Definition/RuntimeDefinition.php
@@ -27,9 +27,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function __construct(?array $explicitClasses = null)
     {
-        if ($explicitClasses) {
-            $this->setExplicitClasses($explicitClasses);
-        }
+        $this->setExplicitClasses($explicitClasses ?? []);
     }
 
     /**
@@ -62,11 +60,6 @@ class RuntimeDefinition implements DefinitionInterface
     public function addExplicitClass(string $class): self
     {
         $this->ensureClassExists($class);
-
-        if (! $this->explicitClasses) {
-            $this->explicitClasses = [];
-        }
-
         $this->explicitClasses[$class] = true;
         return $this;
     }
@@ -94,10 +87,6 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function getClasses(): array
     {
-        if (! $this->explicitClasses) {
-            return array_keys($this->definition);
-        }
-
         return array_keys(array_merge($this->definition, $this->explicitClasses));
     }
 

--- a/src/Definition/RuntimeDefinition.php
+++ b/src/Definition/RuntimeDefinition.php
@@ -19,14 +19,15 @@ class RuntimeDefinition implements DefinitionInterface
     /** @var ClassDefinition[] */
     private array $definition = [];
 
-    /** @var bool[] */
-    private ?array $explicitClasses = null;
+    /** @var array<class-string, bool> */
+    private array $explicitClasses;
 
     /**
-     * @param null|string[] $explicitClasses
+     * @param null|class-string[] $explicitClasses
      */
     public function __construct(?array $explicitClasses = null)
     {
+        $this->explicitClasses = [];
         $this->setExplicitClasses($explicitClasses ?? []);
     }
 
@@ -35,7 +36,7 @@ class RuntimeDefinition implements DefinitionInterface
      *
      * @see addExplicitClass()
      *
-     * @param string[] $explicitClasses An array of class names
+     * @param class-string[] $explicitClasses An array of class names
      * @throws Exception\ClassNotFoundException
      */
     public function setExplicitClasses(array $explicitClasses): self
@@ -55,6 +56,7 @@ class RuntimeDefinition implements DefinitionInterface
      * Adding classes this way will cause the defintion to report them when getClasses()
      * is called, even when they're not yet loaded.
      *
+     * @param class-string $class
      * @throws Exception\ClassNotFoundException
      */
     public function addExplicitClass(string $class): self

--- a/test/Definition/RuntimeDefinitionTest.php
+++ b/test/Definition/RuntimeDefinitionTest.php
@@ -40,7 +40,7 @@ class RuntimeDefinitionTest extends TestCase
         $this->assertEquals($expected, $definition->getClasses());
     }
 
-    public function testSetExplicitClassesReplacesPrefiousValues()
+    public function testSetExplicitClassesReplacesPreviousValues(): void
     {
         $expected = [
             TestAsset\A::class,


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR might be considered a minor refactor/improvement.

Currently in [RuntimeDefinition::__construct()](https://github.com/laminas/laminas-di/blob/3.6.x/src/Definition/RuntimeDefinition.php#L28) a test for truthiness of `$explicitClasses` is done. This means that [RuntimeDefinition::setExplicitClasses()](https://github.com/laminas/laminas-di/blob/3.6.x/src/Definition/RuntimeDefinition.php#L43) is only called whenever the constructor argument`$explicitClasses` is not `null` and not an empty `array`.
This means that after construction, [RuntimeDefinition::$explicitClasses](https://github.com/laminas/laminas-di/blob/3.6.x/src/Definition/RuntimeDefinition.php#L23) can be null, and hence the tests for truthiness throughout some of the methods is required to account for that.
This pull request normalizes the `null` value to an `empty` array in the constructor, simplifying some methods and ensuring that users do not have to deal with tests for `null` in code in case they extend the class.
  
<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
