### PR TITLE
RUNTIME DEFINITION: Update docblocks with `class-string` type

### DIFF
--- a/src/Definition/RuntimeDefinition.php
+++ b/src/Definition/RuntimeDefinition.php
@@ -16,7 +16,7 @@ use function class_exists;
  */
 class RuntimeDefinition implements DefinitionInterface
 {
-    /** @var ClassDefinition[] */
+    /** @var array<class-string, ClassDefinition> */
     private array $definition = [];
 
     /** @var array<class-string, bool> */
@@ -66,6 +66,7 @@ class RuntimeDefinition implements DefinitionInterface
         return $this;
     }
 
+    /** @param class-string $class */
     private function ensureClassExists(string $class): void
     {
         if (! $this->hasClass($class)) {
@@ -74,7 +75,7 @@ class RuntimeDefinition implements DefinitionInterface
     }
 
     /**
-     * @param string $class The class name to load
+     * @param class-string $class The class name to load
      * @throws Exception\ClassNotFoundException
      */
     private function loadClass(string $class): void
@@ -84,9 +85,7 @@ class RuntimeDefinition implements DefinitionInterface
         $this->definition[$class] = new ClassDefinition($class);
     }
 
-    /**
-     * @return string[]
-     */
+    /** @return list<class-string> */
     public function getClasses(): array
     {
         return array_keys(array_merge($this->definition, $this->explicitClasses));
@@ -98,6 +97,7 @@ class RuntimeDefinition implements DefinitionInterface
     }
 
     /**
+     * @param class-string $class
      * @return ClassDefinition
      * @throws Exception\ClassNotFoundException
      */


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR updates the left over methods and property in the `RuntimeDefinition::class` by changing it correctly to `class-string`.

Assuming correct use of the `RuntimeDefinition::class`, the [RuntimeDefinition::getClassDefinition()](https://github.com/laminas/laminas-di/blob/3.7.x/src/Definition/RuntimeDefinition.php#L104) method would call [RuntimeDefinition::loadClass()](https://github.com/laminas/laminas-di/blob/3.7.x/src/Definition/RuntimeDefinition.php#L80) which in turn would call [RuntimeDefinition::ensureClassExists()](https://github.com/laminas/laminas-di/blob/3.7.x/src/Definition/RuntimeDefinition.php#L80). This last method will ensure that `$this->definition[$class]` is set with `$class` being an existent class and hence a `class-string`. As a result, this means that `RuntimeDefinition::$definition`'s type would be `array<class-string, ClassDefinition>` instead of the current type `ClassDefinition[]`.

This also means that `RuntimeDefinitioin::ensureClassExists()` is now only called with values of type `class-string`, hence this is updated as well.

Finally, since both `RuntimeDefinition::$definition` and `RuntimeDefinition::$explicitClasses` have keys of type `class-string`, the return type of [RuntimeDefinition::getClasses()](https://github.com/laminas/laminas-di/blob/3.7.x/src/Definition/RuntimeDefinition.php#L88) must also, hence updated in this PR.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
