### PR TITLE
[Fix] `Parameter::getType()` call to undefined method `getName()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,11 +216,6 @@ parameters:
 			path: src/Definition/Reflection/ClassDefinition.php
 
 		-
-			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
-			count: 1
-			path: src/Definition/Reflection/Parameter.php
-
-		-
 			message: "#^Method Laminas\\\\Di\\\\Injector\\:\\:create\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Injector.php

--- a/src/Definition/Reflection/Parameter.php
+++ b/src/Definition/Reflection/Parameter.php
@@ -58,11 +58,19 @@ class Parameter implements ParameterInterface
      * {@inheritDoc}
      *
      * @see ParameterInterface::getType()
+     *
+     * @throws UnsupportedReflectionTypeException
      */
     public function getType(): ?string
     {
         if ($this->reflection->hasType()) {
-            return $this->reflection->getType()->getName();
+            $type = $this->reflection->getType();
+
+            if ($type !== null && ! $type instanceof ReflectionNamedType) {
+                throw UnsupportedReflectionTypeException::fromUnionOrIntersectionType($type);
+            }
+
+            return $type->getName();
         }
 
         return null;

--- a/test/Definition/Reflection/ParameterTest.php
+++ b/test/Definition/Reflection/ParameterTest.php
@@ -111,7 +111,7 @@ class ParameterTest extends TestCase
     /**
      * @requires PHP >= 8.0
      */
-    public function testGivenUnionTypeToParameterExpectedUnexpectedValueExceptionThrown(): void
+    public function testIsBuiltinGivenUnionTypeExpectedUnsupportedReflectionTypeExceptionThrown(): void
     {
         $this->expectException(UnsupportedReflectionTypeException::class);
 
@@ -125,7 +125,7 @@ class ParameterTest extends TestCase
     /**
      * @requires PHP >= 8.1
      */
-    public function testGivenIntersectionTypeToParameterExpectedUnexpectedValueExceptionThrown(): void
+    public function testIsBuiltinGivenIntersectionTypeExpectedUnsupportedReflectionTypeExceptionThrown(): void
     {
         $this->expectException(UnsupportedReflectionTypeException::class);
 

--- a/test/Definition/Reflection/ParameterTest.php
+++ b/test/Definition/Reflection/ParameterTest.php
@@ -135,4 +135,32 @@ class ParameterTest extends TestCase
 
         $param->isBuiltin();
     }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testGetTypeGivenUnionTypeExpectedUnsupportedReflectionTypeExceptionThrown(): void
+    {
+        $this->expectException(UnsupportedReflectionTypeException::class);
+
+        $class      = TestAsset\Constructor\UnionTypeConstructorDependency::class;
+        $parameters = (new ReflectionClass($class))->getConstructor()->getParameters();
+        $param      = new Parameter($parameters[0]);
+
+        $param->getType();
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testGetTypeGivenIntersectionTypeExpectedUnsupportedReflectionTypeExceptionThrown(): void
+    {
+        $this->expectException(UnsupportedReflectionTypeException::class);
+
+        $class      = TestAsset\Constructor\IntersectionTypeConstructorDependency::class;
+        $parameters = (new ReflectionClass($class))->getConstructor()->getParameters();
+        $param      = new Parameter($parameters[0]);
+
+        $param->getType();
+    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
This PR adds a check to `Parameter::getType()` to ensure a potentially undefined method call `getName()` is not made on either a `ReflectionUnionType::class` or `ReflectionIntersectionType::class` object. This PR also includes two tests for correctness of behavior.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
