### PR TITLE
[Fix] DEFAULT CONTAINER: Documentation & resolved phpstan-baseline error

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -191,11 +191,6 @@ parameters:
 			path: src/Container/ServiceManager/AutowireFactory.php
 
 		-
-			message: "#^Property Laminas\\\\Di\\\\DefaultContainer\\:\\:\\$services type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/DefaultContainer.php
-
-		-
 			message: "#^Method Laminas\\\\Di\\\\Definition\\\\ClassDefinitionInterface\\:\\:getReflection\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#"
 			count: 1
 			path: src/Definition/ClassDefinitionInterface.php

--- a/src/DefaultContainer.php
+++ b/src/DefaultContainer.php
@@ -25,7 +25,7 @@ class DefaultContainer implements ContainerInterface
     /**
      * Registered services and cached values
      *
-     * @var array
+     * @var array<string, object>
      */
     protected $services = [];
 

--- a/src/DefaultContainer.php
+++ b/src/DefaultContainer.php
@@ -80,7 +80,7 @@ class DefaultContainer implements ContainerInterface
      * @see ContainerInterface::get()
      *
      * @param string $name
-     * @return mixed
+     * @return object
      */
     public function get($name)
     {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR updates the type declaration (docblock) of the `DefaultContainer::$services` to the more specific `array<string, object>` and removes the resolved phpstan-baseline error. This type is derived as follows: within the [DefaultContainer::__construct()](https://github.com/laminas/laminas-di/blob/3.8.x/src/DefaultContainer.php#L32), the keys are represented by `class-string` and mapped to values of type `object`. Additionally, [DefaultContainer::setInstance()](https://github.com/laminas/laminas-di/blob/3.8.x/src/DefaultContainer.php#L48) uses `string` type for keys and parameter `$service` is documented as type `object`, meaning that only type `object` occurs as value in `DefaultContainer::$services`.

As a logical consequence, [DefaultContainer::get()](https://github.com/laminas/laminas-di/blob/3.8.x/src/DefaultContainer.php#L83) returns objects based on the aforementioned, and [InjectorInterface::create()](https://github.com/laminas/laminas-di/blob/5c600db280038863d65bb23e8131ecc88b8c0ad1/src/InjectorInterface.php#L21) which is also said to return type `object`. 
Although the `DefaultContainer::get()` is inherit from the `ContainerInterface::class` which has return type `mixed`, the child is allowed to have a more specific return type based on [covariance](https://www.php.net/manual/en/language.oop5.variance.php).

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
