### PR TITLE
Remove `psr/container:^2` support, since our implementation does not respect its interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": ">=7.4, <8.2",
         "laminas/laminas-stdlib": "^3.6",
-        "psr/container": "^1.1.1 || ^2.0.0",
+        "psr/container": "^1.1.1",
         "psr/log": "^1.1.4 || ^3.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bffbef8c59dd490f8b09e73a9542370",
+    "content-hash": "430ec6b5fade593fabd8a716b5ff4f71",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",


### PR DESCRIPTION
Reverts #72
Fixes #74

Because of our default container implementation not having return type declarations,
and because our container not being `final` (and therefore not being able to change
this without BC breaks), we cannot support `psr/container:^2` for now.

In #72 we erroneously introduced `psr/container:^2` support, but our CI did never
verify this, because our constraints do not allow for its installation, and therefore
we never verified its compatibility.

This means that `3.9.0` will effectively be preferred over `3.9.1`, if people
depend on `psr/container:^2`, but sadly, such is the problem with already tagged
releases and dependency SAT mechanisms.


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
