### PR TITLE
Add psr/log ^2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "laminas/laminas-stdlib": "^3.18.0",
         "psr/container": "^1.1.1",
-        "psr/log": "^1.1.4 || ^3.0.0"
+        "psr/log": "^1.1.4 || ^2.0.0 ||  ^3.0.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8889cb6a3a8f7a1b8b7a79b0b4a5f8a8",
+    "content-hash": "d07e1b133a8f020e97133656a93f4d10",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -3682,12 +3682,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

It makes no sense supporting ^3, but not supporting ^2. And since symfony ^5 only supports ^1|^2 and some other packages only support ^2|^3 this is an issue.

Related: https://github.com/laminas/laminas-di/issues/49