### PR TITLE
Update factory.template because of PHP8.4 deprecation

### DIFF
--- a/templates/factory.template
+++ b/templates/factory.template
@@ -26,7 +26,7 @@ final class %factory_class% implements FactoryInterface
      * @param array<mixed>|string|null $name
      * @param array<mixed>|null $options
      */
-    public function __invoke(ContainerInterface $container, $name = null, array $options = null): %class%
+    public function __invoke(ContainerInterface $container, $name = null, ?array $options = null): %class%
     {
         if (is_array($name) && $options === null) {
             $options = $name;


### PR DESCRIPTION
Implicitly marking parameter $options as nullable is deprecated in PHP8.4, the explicit nullable type must be used instead